### PR TITLE
LIBITD-2621. Change OpenLdap to "bitnamilegacy/openldap" Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
     driver: bridge
 services:
   openldap:
-    image: bitnami/openldap:2.5.16
+    image: bitnamilegacy/openldap:2.5.16
     container_name: openldap
     ports:
       - '1389:1389'


### PR DESCRIPTION
Updated the OpenLdap Docker container in the "docker-compose.yml" file to use the "bitnamilegacy/openldap" Docker image.

As discussed in <https://github.com/bitnami/containers/issues/83267>, existing Bitnami Docker images are being moved to a "bitnamilegacy" Docker namespace, and will no longer get updates.

This Docker image is only used for local development, so the fact that it not does get updates is not a security issue.

https://umd-dit.atlassian.net/browse/LIBITD-2621