### PR TITLE
LIBITD-2589. Updates for Rails 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ borrow-local$ cd /root/reciprocal-borrowing
 borrow-local$ bundle config set force_ruby_platform true
 borrow-local$ bundle config set --local path 'vendor/bundle'
 borrow-local$ bundle install
+borrow-local$ yarn install
+borrow-local$ yarn watch:css
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
     driver: bridge
 services:
   openldap:
-    image: bitnami/openldap:2.5.16
+    image: bitnamilegacy/openldap:2.5.16
     container_name: openldap
     ports:
       - '1389:1389'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     networks:
       - reciprocal-borrowing-network
   borrow-local:
-    image: docker.lib.umd.edu/shib-sp-reciprocal-borrowing:ruby-3.2.2
+    image: docker.lib.umd.edu/shib-sp-reciprocal-borrowing:ruby-3.2.2-rail-8.1
     container_name: borrow-local
     ports:
       - '80:80'

--- a/sp/Dockerfile
+++ b/sp/Dockerfile
@@ -100,8 +100,8 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | b
     [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" && \
     nvm install 18
 
-# Install yarn
-RUN npm install -g yarn
+# Install yarn and nodemon for local development
+RUN npm install -g yarn nodemon
 
 # Set permissions to /root to enable Apache to access it
 RUN chmod 755 /root

--- a/sp/Dockerfile
+++ b/sp/Dockerfile
@@ -38,7 +38,7 @@ RUN openssl req -new -nodes -newkey rsa:2048 -subj "/commonName=localhost.locald
 RUN openssl x509 -req -days 1825 -in localhost.csr -signkey /etc/pki/tls/private/localhost.key -out /etc/pki/tls/certs/localhost.crt
 RUN sed -i '/^[[:space:]]*CustomLog/s/^/#/' /etc/httpd/conf/httpd.conf
 
-# add a basic page to shibb's default protected directory
+# add a basic page to shibd's default protected directory
 RUN mkdir -p /var/www/html/secure/; mkdir -p /opt/tier/
 ADD container_files/httpd/index.html /var/www/html/secure/
 
@@ -93,6 +93,15 @@ RUN yum update -y && \
     yum install -y mod_passenger || { yum-config-manager --enable cr && sudo yum install -y mod_passenger ; } && \
     yum clean all
 
+# Install NVM and Node
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
+    export NVM_DIR="$HOME/.nvm" && \
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" && \
+    nvm install 18
+
+# Install yarn
+RUN npm install -g yarn
+
 # Set permissions to /root to enable Apache to access it
 RUN chmod 755 /root
-

--- a/sp/container_files/httpd/00-virtualhosts.conf
+++ b/sp/container_files/httpd/00-virtualhosts.conf
@@ -1,5 +1,5 @@
-# Set "development_docker" as the Rails environment (instead of "development")
-RailsEnv development_docker
+# Set "development" as the Rails environment
+RailsEnv development
 
 <VirtualHost *:80>
     ServerName borrow-local

--- a/sp/container_files/system/startup.sh
+++ b/sp/container_files/system/startup.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Ensure that the /run/shibboleth directory exists for the Shibboleth socket
+mkdir -p /run/shibboleth
+
 #for passed-in env vars, remove spaces and replace any ; with : in usertoken env var since we will use ; as a delimiter
 export USERTOKEN="${USERTOKEN//;/:}"
 export USERTOKEN="${USERTOKEN// /}"


### PR DESCRIPTION
* Updated the OpenLdap Docker container in the "docker-compose.yml" file to use the "bitnamilegacy/openldap" Docker image.

As discussed in https://github.com/bitnami/containers/issues/83267, existing Bitnami Docker images are being moved to a "bitnamilegacy" Docker namespace, and will no longer get updates.

This Docker image is only used for local development, so the fact that it not does get updates is not a security issue.

* Updated "Dockerfile" for Rails 8.1 - nvm, node, yarn

* Updated the Dockerfile to install nvm, version 18 of Node, and yarn
to support compiling the assets using Rails 8.1 asset pipeline.

* Updated the "borrow-local" Docker image to
docker.lib.umd.edu/shib-sp-reciprocal-borrowing:ruby-3.2.2-rail-8.1
to utilize the changes made to the "sp/Dockerfile" in this issue.

https://umd-dit.atlassian.net/browse/LIBITD-2589